### PR TITLE
Add prod use warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 PHP Method Overloading [![Build Status](https://travis-ci.org/craig-davis/php-method-overloading.svg?branch=master)](https://travis-ci.org/craig-davis/php-method-overloading)
 ================================================================================
 
+> This is a proof of concept and should not be considered for production use.
+
 Add the `Overloading` trait to a class to help implement type hinted overloading and delegation.
 
 ```php
@@ -10,7 +12,7 @@ $cart
     ->addItem('A candybar', 1.53);
 ```
 
-Delegates correctly to an implementation for each parameter signature. 
+Delegates correctly to an implementation for each parameter signature.
 
 ```php
 public function addItem(...$args);


### PR DESCRIPTION
## Feature

Let's make sure nobody uses this in a production project.

## Solution

Add a warning banner to the readme file.